### PR TITLE
Major refactor to the code. Details follow.

### DIFF
--- a/source/audiofile.hpp
+++ b/source/audiofile.hpp
@@ -4,70 +4,23 @@
 #include <switch.h>
 #include <samplerate.h>
 
+#include "metadata.hpp"
 #include "util.hpp"
 #include "playback.hpp"
 
+#include "decoder.hpp"
 
 using namespace std;
-
-typedef string vorbisFile;
-typedef string flacFile;
-typedef string mp3File;
-typedef string wavFile;
-typedef string modFile;
-
-struct metadata {
-	string filename;
-	string filetype;
-	string artist;
-	string album;
-	string title;
-	string fancyftype;
-	u16 bitrate;
-	int samplerate;
-	u32 length;
-	u32 currtime;
-	u8 channels;
-	u8 bitdepth;
-	vector<string> other;
-};
-
-class decoder {
-	public:
-		decoder();
-		virtual ~decoder();
-		bool decoderValid;
-		string decoderError;
-		virtual void start();
-		virtual void stop();
-		virtual bool checkRunning();
-		virtual long tell();
-		virtual long tell_time();
- 		virtual long length();
-		virtual long length_time();
-		virtual int seek(long position);
-		virtual int seek_time(double time);
-		virtual int get_bitrate();
-		metadata Metadata;
-	protected:
-		Thread decodingThread;
-		Mutex decodeLock = 0;
-		CondVar decodeStatusCV;
-		Mutex decodeStatusLock = 0;
-		s16 *decodeBuffer;
-		u32 decodeBufferSize;
-		bool decodeRunning;		
-};
 
 class audioFile {
 	public:
 		decoder *Decoder;
 		audioFile(const string& filename);
 		~audioFile();
-		void loadFile();
-		float secondsFromSamples(int samples);
-		int samplesFromSeconds(float seconds);
-		metadata Metadata;
+		void load_file();
+		void update_metadata(bool firstrun);
+		metadata_t metadata; // a copy of the decoder's metadata
+	
 };
 
 #endif

--- a/source/decoder.cpp
+++ b/source/decoder.cpp
@@ -1,0 +1,128 @@
+#include "decoder.hpp"
+
+decoder::decoder() {
+	this->decoderValid = false;
+	this->decoderError = "";
+	condvarInit(&this->decodeStatusCV, &this->decodeStatusLock);
+	mutexLock(&this->decodeLock);
+	mutexUnlock(&this->decodeLock);
+	this->metadata.filename = "Unknown";
+	this->metadata.filetype = "Unknown";
+	this->metadata.title = "Unknown";
+	this->metadata.artist = "Unknown";
+	this->metadata.album = "Unknown";
+	this->metadata.bitrate = 0;
+	this->metadata.samplerate = 48000;
+	this->metadata.channels = 2;
+	this->metadata.bitdepth = 16;
+	this->metadata.length = 0;
+	this->metadata.currtime = 0;
+	this->metadata.fancyftype = "Unknown";
+}
+
+
+decoder::~decoder() {
+}
+
+
+/* metadata_t decoder::get_metadata() {
+	metadata_t m;
+	mutexLock(&this->metadataLock);
+	condvarWait(&this->metadataCV);
+	m = this->metadata;
+	mutexUnlock(&this->metadataLock);
+	return m;
+} */ // Shallow copies are bad mmk. Was causing crashes.
+
+
+metadata_t decoder::get_metadata(bool firstrun) {
+	mutexLock(&this->metadataLock);
+	condvarWait(&this->metadataCV);
+	metadata_t m;
+	if (firstrun) {
+		m.filename = this->metadata.filename.data();
+		m.filetype = this->metadata.filetype.data();
+		m.artist = this->metadata.artist.data();
+		m.album = this->metadata.album.data();
+		m.title = this->metadata.title.data();
+		m.fancyftype = this->metadata.fancyftype.data();
+		m.other.clear();
+		for (auto & i : this->metadata.other) {
+			m.other.push_back(i);
+		}
+		m.channels = this->metadata.channels;
+		m.bitdepth = this->metadata.bitdepth;
+	} else {
+		m.filename = "";
+		m.filetype = "";
+		m.artist = "";
+		m.album = "";
+		m.title = "";
+		m.fancyftype = "";
+		m.other.clear();
+		m.channels = 2;
+		m.bitdepth = 16;
+	}
+	m.bitrate = this->metadata.bitrate;
+	m.samplerate = this->metadata.samplerate;
+	m.length = this->metadata.length;
+	m.length_pcm = this->metadata.length_pcm;
+	m.currtime = this->metadata.currtime;
+	m.currpcm = this->metadata.currpcm;
+	mutexUnlock(&this->metadataLock);
+	return m;
+}
+
+/* void decoder::set_metadata(metadata_t in) {
+	mutexLock(&this->metadataLock);
+	
+	this->metadata = in;
+	condvarWakeAll(&this->metadataCV);
+	mutexUnlock(&this->metadataLock);
+}
+ */ // Avoiding shallow copies here too.
+
+void decoder::set_metadata(metadata_t in, bool firstrun) {	
+	mutexLock(&this->metadataLock);
+	if (firstrun) {
+		this->metadata.filename = in.filename.data();
+		this->metadata.filetype = in.filetype.data();
+		this->metadata.artist = in.artist.data();
+		this->metadata.album = in.album.data();
+		this->metadata.title = in.title.data();
+		this->metadata.fancyftype = in.fancyftype.data();
+		this->metadata.channels = in.channels;
+		this->metadata.bitdepth = in.bitdepth;
+		this->metadata.other.clear();
+		for (auto & i : in.other) {
+			this->metadata.other.push_back(i);
+		}
+	}
+	this->metadata.bitrate = in.bitrate;
+	this->metadata.samplerate = in.samplerate;
+	this->metadata.length = in.length;
+	this->metadata.length_pcm = in.length_pcm;
+	this->metadata.currtime = in.currtime;
+	this->metadata.currpcm = in.currpcm;
+	condvarWakeAll(&this->metadataCV);
+	mutexUnlock(&this->metadataLock);
+}
+
+// Here there be stubs. These are all 'defaults' for virtual functions intended to be overridden by specific decoders.
+
+void decoder::start() {} // Should start the decode thread, and begin filling the playback buffer with fillPlayBuffer
+
+void decoder::stop() {} // Should stop the decode thread.	
+
+bool decoder::check_running() { return false; } // Should return whether or not the decode thread is active.
+
+int decoder::seek(long position) { // Should seek to a position given in PCM samples.
+	return 0;
+}
+
+void decoder::parse_metadata() {}; // Deal with metadata, initial and subsequent
+void decoder::update_metadata() {};
+
+int decoder::seek_time(double time) { // Should seek to a position given in seconds.
+	return 0;
+}

--- a/source/decoder.hpp
+++ b/source/decoder.hpp
@@ -1,0 +1,43 @@
+#ifndef DECODER_H
+#define DECODER_H
+#include <switch.h>
+#include <string>
+#include "metadata.hpp"
+using namespace std;
+
+class decoder {
+	public:
+		decoder();
+		virtual ~decoder();
+		bool decoderValid;
+		string decoderError;
+		virtual void start();
+		virtual void stop();
+		virtual bool check_running();
+		virtual int seek(long position);
+		virtual int seek_time(double time);
+		metadata_t get_metadata(bool firstrun);
+		void set_metadata(metadata_t in, bool firstrun);
+		
+	protected:
+		virtual void parse_metadata();
+		virtual void update_metadata();
+		metadata_t metadata;
+		Thread decodingThread;
+		Mutex decodeLock = 0;
+		CondVar decodeStatusCV;
+		Mutex decodeStatusLock = 0;
+		CondVar metadataCV;
+		Mutex metadataLock = 0;
+		s16 *decodeBuffer;
+		u32 decodeBufferSize;
+		bool decodeRunning;		
+};
+
+// Add new decoders in here so audiofile can access them.
+#ifdef IN_AUDIOFILE
+#include "vorbisdec.hpp"
+//#include "mp3dec.hpp"
+#endif
+
+#endif

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -72,13 +72,13 @@ int audioLoop(const string& musicfile) {
 	consoleClear();
 	string outstr = "";
 		
-	outstr += "SchalterVox Alpha\nNow Playing: "; //row0 end
+	outstr += "SchalterVox Alpha\n"; //row0 end
 	
 	string tmp;
 	if (af->metadata.artist != "Unknown") {
-		tmp = af->metadata.artist + " - " + af->metadata.title;
+		tmp = "Now Playing: " + af->metadata.artist + " - " + af->metadata.title;
 	} else { 
-		tmp = af->metadata.title;
+		tmp = "Now Playing: " + af->metadata.title;
 	}
 	if (tmp.length()>80) {
 		tmp.resize(76);

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -69,30 +69,40 @@ int audioLoop(const string& musicfile) {
 	af->update_metadata(true);
 	af->Decoder->start();
 	
+	consoleClear();
+	string outstr = "";
+		
+	outstr += "SchalterVox Alpha\nNow Playing: "; //row0 end
+	
+	string tmp;
+	if (af->metadata.artist != "Unknown") {
+		tmp = af->metadata.artist + " - " + af->metadata.title;
+	} else { 
+		tmp = af->metadata.title;
+	}
+	if (tmp.length()>80) {
+		tmp.resize(76);
+		tmp = tmp + "...";
+	}
+	outstr += tmp + "\n"; //row1 end
+	if (af->metadata.album != "Unknown") {
+		outstr += "Album: ";
+		outstr += af->metadata.album;		
+	}
+	outstr += "\n"; //row2 end
+
+	outstr += to_string(af->metadata.bitrate) + "kbps ";
+	outstr += to_string(af->metadata.samplerate) + "Hz ";
+	outstr += to_string(af->metadata.bitdepth) + "bit ";
+	outstr += name_channels(af->metadata.channels); 
+	outstr += " " + af->metadata.fancyftype + "\n"; //row3 end
+	printf(outstr.c_str());
 
 	while (active) {
-		consoleClear();
 		af->update_metadata(false);
-		string outstr = "";
-		
-		outstr += "SchalterVox Alpha\nNow Playing: ";
-
-		if (af->metadata.artist != "Unknown") {
-			outstr += af->metadata.artist + " - " + af->metadata.title;
-		} else {
-			outstr += af->metadata.title;
-		}
-		outstr += "\n";
-		if (af->metadata.album != "Unknown") {
-			outstr += "Album: ";
-			outstr += af->metadata.album;
-			outstr += "\n";
-		}
-		outstr += to_string(af->metadata.bitrate) + "kbps ";
-		outstr += to_string(af->metadata.samplerate) + "Hz ";
-		outstr += to_string(af->metadata.bitdepth) + "bit ";
-		outstr += name_channels(af->metadata.channels);
-		outstr += " " + af->metadata.fancyftype + "\nTime: ";
+		outstr = "";
+		printf("\x1b[5;0H"); // move to the 5th row, first column		
+		outstr += "Time: ";
 		outstr += convert_time(af->metadata.currtime);
 		outstr += "/";
 		outstr += convert_time(af->metadata.length);

--- a/source/metadata.hpp
+++ b/source/metadata.hpp
@@ -1,0 +1,29 @@
+#ifndef METADATA_H
+#define METADATA_H
+#include <string>
+#include <switch.h>
+#include <vector>
+
+using namespace std;
+
+
+
+struct metadata_t {
+	string filename;
+	string filetype;
+	string artist;
+	string album;
+	string title;
+	string fancyftype;
+	u16 bitrate=0;
+	int samplerate=48000;
+	u32 length=0;
+	u32 length_pcm=0;
+	u32 currtime=0;
+	u32 currpcm=0;
+	u8 channels=2;
+	u8 bitdepth=16;
+	vector<string> other;
+};
+
+#endif

--- a/source/playback.cpp
+++ b/source/playback.cpp
@@ -57,21 +57,15 @@ void stop_playback(bool playout) {
 		}
 		u64 sleepnano = 4000000000/AUDIO_BUFFER_DIVIDER; // Sleep for 4x the system buffer size, to drain all buffers.
 		svcSleepThread(sleepnano);
-		printf("DEBUG: Slept.\n");
 	}
 	
-	printf("DEBUG: Waiting to signal audio to quit...\n");
 	mutexLock(&aStatusLock);
 	condvarWait(&aStatusCV);
-	printf("DEBUG: Signalling audio to quit...\n");
 	playing = false;
 	mutexUnlock(&aStatusLock);
-	printf("DEBUG: Waiting for thread to exit...\n");
 	threadWaitForExit(&playback_thread);
-	printf("DEBUG: Thread exited, waiting for audio to stop...\n");
 	audoutStopAudioOut();
 	audoutExit();
-	printf("DEBUG: Audio stopped. leaving stop_playback()\n");
 }
 
 void abort_playback() { // Used for errors.

--- a/source/playback.cpp
+++ b/source/playback.cpp
@@ -36,7 +36,18 @@ void set_samplerate(int sr) {
 }
 
 void stop_playback(bool playout) {
-	if (playout) {
+	// TODO: Fix playout for resampled audio. Currently causes freeze.
+	//       Suspected causes include buffer overflow (shouldn't be 
+	//       possible given the size of atb) or strange/undefined behavior 
+	//       at low atbUsed values (due to mismatch between buffer size, 
+	//		 which is based on device samplerate, and amount of buffer 
+	//       consumed, in a pass, based on input samplerate.
+	//		 Unsure how to fix atm, and it's better to just stub out 
+	//       the functionality (given the small buffer sizes playout 
+	//       isn't noticeable anyway) than have people testing the
+	//       release end up corrupting their filesystems from a hard freeze
+	//       with open handles, as has happened to be repeatedly now.
+	if (playout && (current_samplerate==AUDIO_SAMPLERATE)) {
 		bool flsh = false;
 		while (!flsh) { // Wait for the buffer to empty before terminating.
 			mutexLock(&aStatusLock);
@@ -46,15 +57,21 @@ void stop_playback(bool playout) {
 		}
 		u64 sleepnano = 4000000000/AUDIO_BUFFER_DIVIDER; // Sleep for 4x the system buffer size, to drain all buffers.
 		svcSleepThread(sleepnano);
+		printf("DEBUG: Slept.\n");
 	}
 	
+	printf("DEBUG: Waiting to signal audio to quit...\n");
 	mutexLock(&aStatusLock);
 	condvarWait(&aStatusCV);
+	printf("DEBUG: Signalling audio to quit...\n");
 	playing = false;
 	mutexUnlock(&aStatusLock);
+	printf("DEBUG: Waiting for thread to exit...\n");
 	threadWaitForExit(&playback_thread);
+	printf("DEBUG: Thread exited, waiting for audio to stop...\n");
 	audoutStopAudioOut();
 	audoutExit();
+	printf("DEBUG: Audio stopped. leaving stop_playback()\n");
 }
 
 void abort_playback() { // Used for errors.
@@ -107,7 +124,7 @@ void playback_thread_main(void *) {
 		audoutWaitPlayFinish(&released, &cnt, U64_MAX);
 
 		mutexLock(&aLock);		
-		if (atbUsed != 0) {
+		if (atbUsed > 0) {
 			mutexLock(&aStatusLock);
 			flushing = false;
 			condvarWakeAll(&aStatusCV);
@@ -130,9 +147,10 @@ void playback_thread_main(void *) {
 				atbUsed -= size / sizeof(u32);
 				memmove(atb, atb + (size / sizeof(u32)), atbUsed * sizeof(u32));
 			} else {
-				resampleBuffer((short*)released->buffer, AUDIO_BUFFER_SAMPLES);
+				resampleBuffer((short*)released->buffer, (size / sizeof(u32)));
 				int outsize = (size * current_samplerate) / (sizeof(u32) * AUDIO_SAMPLERATE); 
 				atbUsed -= outsize;
+				if (atbUsed<0) atbUsed=0;
 				memmove(atb, atb + outsize, atbUsed * sizeof(u32));
 			}
 			audoutAppendAudioOutBuffer(released);

--- a/source/vorbisdec.hpp
+++ b/source/vorbisdec.hpp
@@ -2,6 +2,7 @@
 #include <vorbis/vorbisfile.h>
 #include <string>
 #include <sstream>
+#include "decoder.hpp"
 
 void vorbisdecoder_trampoline(void *parameter);
 
@@ -20,17 +21,16 @@ class vorbisdecoder : public decoder {
 		void stop();
 		long tell();
 		long tell_time();
- 		long length();
-		long length_time();
 		int seek(long position);
 		int seek_time(double time);
-		int get_bitrate();
-		bool checkRunning();
+		bool check_running();
 		vorbis_info* info;
 		vorbis_comment* comment;
 		void main_thread(void *); // This should really be private, but it needs to be public due to the thread trampoline.
+		void parse_metadata();
+		void update_metadata();
 	private:
 		OggVorbis_File vorbisFile;
 		int section;
-		
+		string fn;
 };


### PR DESCRIPTION
 * Decoders now share a metadata structure, which is also shared with audiofile.
 * Amount of code in the audioFile object for each decoder substantially decreased.
 * Decoders should now be easier to plug in.
 * Decoder and metadata source/headers split from audiofile.

OTHER CHANGES:

 * Reworked text UI.
 * Minor changes to playback thread
   * Specifically, failed attempts to fix freeze bug with resampled audio. See 'new bugs' later.
   * Despite not fixing the bug, changes kept because many made sense anyway.
 * Streamlined vorbis decoder.

NEW BUGS:

 * Extremely rare crash during playback
   * This appears to be a thread safety issue, though I'm using
     mutexes properly so I don't know what's going on. Does not happen if you stub out the call
     to update the audioFile's metadata while the decode thread is running, but this disables
     tracking of current time in file.
 * Freeze at end of file if 'playout' enabled for resampled audio.
   * 'playout' is what causes the audio thread to play out it's last few buffers after the decode
     thread has terminated. This is a maximum of about 300ms (usually 200ms or much lower) of audio
     that may still potentially be in the audio transfer buffer once the decode has completed.
     However, when 'playing out' resampled audio, there are issues due to the amount of buffer consumed
     on each pass being less than a factor of the buffer size. As the value of atbUsed (the amount
     of buffer in use) decreases on each pass, it eventually reaches an amount smaller than the
     amount needed to be consumed to create one burst of resampled audio. This causes various
     undefined behaviors, mostly crashes. As such, 'playout' has been disabled automatically
     for resampled audio, even on a natural track change to avoid these problems for now,
     until I can come up with a fix.
 * Flickering UI
   * A side effect of the way I'm 'drawing' the UI text. Will be fixed soon.